### PR TITLE
fix: hardDrop should use actual piece height, not fixed 4x4 matrix height

### DIFF
--- a/tetris/src/game/tetromino.cc
+++ b/tetris/src/game/tetromino.cc
@@ -211,13 +211,25 @@ void Tetromino::moveRight(std::vector<std::vector<std::string>> grid)
 
 void Tetromino::hardDrop(const std::vector<Coords>& boardBaseline)
 {
+    // Trim empty rows at bottom of the 4x4 bounding box
+    std::int16_t pieceBottom = y.begin;
+    for (auto row = y.begin; row <= y.end; ++row) {
+        for (auto col = x.begin; col <= x.end; ++col) {
+            if (matrix[row - y.begin][col - x.begin] != " ") {
+                pieceBottom = row;
+                break;
+            }
+        }
+    }
+    std::int16_t pieceHeight = pieceBottom - y.begin + 1;
+
     std::int16_t highestY = boardBaseline[0].y;
     for (const auto& coord : boardBaseline)
     {
         if (coord.y < highestY) highestY = coord.y;
     }
     y.end   = highestY;
-    y.begin = static_cast<std::int16_t>(y.end - matrix.size() + 1);
+    y.begin = static_cast<std::int16_t>(y.end - pieceHeight + 1);
 }
 
 void Tetromino::softDrop()


### PR DESCRIPTION
## Bug
When a tetromino has empty rows at the bottom of its 4x4 bounding box,
the hard drop positions it incorrectly because it uses `matrix.size()` (always 4)
instead of the actual piece height.

## Fix
Trim empty rows from the bottom of the bounding box before calculating
the drop position.

Fixes #3

_AI disclosure: Codex (OpenAI) was used to accelerate this fix._